### PR TITLE
Protect value_view's bind from operating on nullptr

### DIFF
--- a/inst/include/fastad_bits/reverse/core/value_view.hpp
+++ b/inst/include/fastad_bits/reverse/core/value_view.hpp
@@ -54,8 +54,11 @@ struct ValueView<ValueType, scl>
      * Binds value pointer to view the same value that val_begin points to.
      * @return  the next pointer from val_begin that is not viewed by current object.
      */
-    value_t* bind(value_t* begin)
-    { val_ = begin; return val_ + this->size(); }
+    value_t* bind(value_t* begin) {
+      if (begin == nullptr) return nullptr;
+      val_ = begin;
+      return val_ + this->size();
+    }
 
     /**
      * Returns the raw pointer to the first value viewed by current object.


### PR DESCRIPTION
This addresses a clang-ubsan issue reported at CRAN:

```r
> data(trees)   # also used in help(lm)
> X <- as.matrix(cbind(const=1, trees[, c("Girth", "Height")]))
> y <- trees$Volume
> linear_regression(X, y, rep(0, 3), tol=1e-12)
../inst/include/fastad_bits/reverse/core/value_view.hpp:58:33: runtime error: applying non-zero offset 8 to null pointer
    #0 0x7f2a66f6015b in ad::core::ValueView<double, ad::scl>::bind(double*) /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/../inst/include/fastad_bits/reverse/core/value_view.hpp:58:33
    #1 0x7f2a66f6015b in ad::core::ValueAdjView<double, ad::scl>::bind(ad::util::PtrPack<double>) /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/../inst/include/fastad_bits/reverse/core/value_adj_view.hpp:50:31
    #2 0x7f2a66f6015b in ad::core::NormNode<ad::core::BinaryNode<ad::core::Sub, ad::core::Constant<double, ad::vec>, ad::core::DotNode<ad::core::Constant<double, ad::mat>, ad::VarView<double, ad::vec> > > >::bind_cache(ad::util::PtrPack<double>) /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/../inst/include/fastad_bits/reverse/core/norm.hpp:65:35
    #3 0x7f2a66f6015b in ad::core::ExprBind<ad::core::NormNode<ad::core::BinaryNode<ad::core::Sub, ad::core::Constant<double, ad::vec>, ad::core::DotNode<ad::core::Constant<double, ad::mat>, ad::VarView<double, ad::vec> > > > >::ExprBind(ad::core::NormNode<ad::core::BinaryNode<ad::core::Sub, ad::core::Constant<double, ad::vec>, ad::core::DotNode<ad::core::Constant<double, ad::mat>, ad::VarView<double, ad::vec> > > > const&) /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/../inst/include/fastad_bits/reverse/core/bind.hpp:32:15
    #4 0x7f2a66f5c642 in auto ad::bind<ad::core::NormNode<ad::core::BinaryNode<ad::core::Sub, ad::core::Constant<double, ad::vec>, ad::core::DotNode<ad::core::Constant<double, ad::mat>, ad::VarView<double, ad::vec> > > > >(ad::core::ExprBase<ad::core::NormNode<ad::core::BinaryNode<ad::core::Sub, ad::core::Constant<double, ad::vec>, ad::core::DotNode<ad::core::Constant<double, ad::mat>, ad::VarView<double, ad::vec> > > > > const&) /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/../inst/include/fastad_bits/reverse/core/bind.hpp:48:12
    #5 0x7f2a66f5c642 in linear_regression(Eigen::Map<Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0, Eigen::Stride<0, 0> >, Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >, Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >, double, unsigned long, double) /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/linear_regression.cpp:49:17
    #6 0x7f2a66f16ee1 in _RcppFastAD_linear_regression /data/gannet/ripley/R/packages/tests-clang-SAN/RcppFastAD/src/RcppExports.cpp:41:34
    #7 0x55baa493f654 in R_doDotCall /data/gannet/ripley/R/svn/R-devel/src/main/dotcode.c:884:17
    #8 0x55baa4987245 in do_dotcall /data/gannet/ripley/R/svn/R-devel/src/main/dotcode.c:1551:11
    #9 0x55baa4aa5d66 in bcEval /data/gannet/ripley/R/svn/R-devel/src/main/eval.c:7391:14
    #10 0x55baa4a90b79 in Rf_eval /data/gannet/ripley/R/svn/R-devel/src/main/eval.c:1013:8
    #11 0x55baa4af9dc9 in R_execClosure /data/gannet/ripley/R/svn/R-devel/src/main/eval.c
    #12 0x55baa4af58c6 in Rf_applyClosure /data/gannet/ripley/R/svn/R-devel/src/main/eval.c:2109:16
    #13 0x55baa4a91475 in Rf_eval /data/gannet/ripley/R/svn/R-devel/src/main/eval.c:1136:12
    #14 0x55baa4be3c75 in Rf_ReplIteration /data/gannet/ripley/R/svn/R-devel/src/main/main.c:262:2
    #15 0x55baa4be7430 in R_ReplConsole /data/gannet/ripley/R/svn/R-devel/src/main/main.c:314:11
    #16 0x55baa4be7226 in run_Rmainloop /data/gannet/ripley/R/svn/R-devel/src/main/main.c:1200:5
    #17 0x55baa4be7572 in Rf_mainloop /data/gannet/ripley/R/svn/R-devel/src/main/main.c:1207:5
    #18 0x55baa46e667c in main /data/gannet/ripley/R/svn/R-devel/src/main/Rmain.c:29:5
    #19 0x7f2a7722950f in __libc_start_call_main (/lib64/libc.so.6+0x2950f) (BuildId: 8257ee907646e9b057197533d1e4ac8ede7a9c5c)
    #20 0x7f2a772295c8 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x295c8) (BuildId: 8257ee907646e9b057197533d1e4ac8ede7a9c5c)
    #21 0x55baa460d264 in _start (/data/gannet/ripley/R/R-clang-SAN/bin/exec/R+0x318264)
```

I have by now received mail by the automated scripts looking for these and we have a leisurely two weeks to upload a fix, I will do so next weekend and will try to add a new set of tests too.

```
From: Prof Brian Ripley <ripley ....redacted just in case...>                                                                                                                                   
To: edd@debian.org                                                                                                                                                                
Cc: CRAN@R-project.org                                                                                                                                                            
Subject: CRAN package RcppFastAD                                                                                                                                                  
Date: Wed, 01 Mar 2023 08:33:28 +0000                                                                                                                                             
                                                                                                                                                                                  
Dear maintainer,                                                                                                                                                                  
                                                                                                                                                                                  
Please see the problems shown on                                                                                                                                                  
<https://cran.r-project.org/web/checks/check_results_RcppFastAD.html>.                                                                                                            
                                                                                                                                                                                  
Please correct before 2023-03-15 to safely retain your package on CRAN.                                                                                                           
                                                                                                                                                                                  
Do remember to look at the 'Additional issues'.                                                                                                                                   
                                                                                                                                                                                  
The CRAN Team                                                                                                                                                                     
```                     
