### PR TITLE
Add fix to clang empty variadic macro arguments

### DIFF
--- a/inst/include/fastad_bits/forward/core/forward.hpp
+++ b/inst/include/fastad_bits/forward/core/forward.hpp
@@ -35,7 +35,14 @@
 // } 
 //
 // Note that we only compute std::exp(x.get_value()) once and reuse to compute both "first" and "second".
-#define FORWARD_UNARY_FUNC(f, first, second, ...) \
+#define FORWARD_UNARY_FUNC(f, first, second) \
+template <class T> \
+inline auto f(const ad::core::ADForward<T>& x) \
+{ \
+	return ad::core::ADForward<T>(first, second); \
+} \
+
+#define FORWARD_UNARY_FUNC_PRE(f, first, second, ...) \
 template <class T> \
 inline auto f(const ad::core::ADForward<T>& x) \
 { \
@@ -112,7 +119,7 @@ FORWARD_UNARY_FUNC(sin, std::sin(x.get_value()),
 FORWARD_UNARY_FUNC(cos, std::cos(x.get_value()), 
         -std::sin(x.get_value())*x.get_adjoint())
 // ad::tan(core::ADForward)
-FORWARD_UNARY_FUNC(tan, std::tan(x.get_value()), 
+FORWARD_UNARY_FUNC_PRE(tan, std::tan(x.get_value()), 
         tmp*tmp * x.get_adjoint(), auto tmp = 1 / std::cos(x.get_value());)
 // ad::asin(core::ADForward)
 FORWARD_UNARY_FUNC(asin, std::asin(x.get_value()), 
@@ -124,16 +131,16 @@ FORWARD_UNARY_FUNC(acos, std::acos(x.get_value()),
 FORWARD_UNARY_FUNC(atan, std::atan(x.get_value()), 
         x.get_adjoint() / (1 + x.get_value()*x.get_value()))
 // ad::exp(core::ADForward)
-FORWARD_UNARY_FUNC(exp, tmp, tmp * x.get_adjoint(), 
+FORWARD_UNARY_FUNC_PRE(exp, tmp, tmp * x.get_adjoint(), 
         auto tmp = std::exp(x.get_value());)
 // ad::log(core::ADForward)
 FORWARD_UNARY_FUNC(log, std::log(x.get_value()), 
         x.get_adjoint() / x.get_value())
 // ad::sqrt(core::ADForward)
-FORWARD_UNARY_FUNC(sqrt, tmp, x.get_adjoint() / (2 * tmp), 
+FORWARD_UNARY_FUNC_PRE(sqrt, tmp, x.get_adjoint() / (2 * tmp), 
         auto tmp = std::sqrt(x.get_value());)
 // ad::erf(core::ADForward)
-FORWARD_UNARY_FUNC(erf, std::erf(x.get_value()), 
+FORWARD_UNARY_FUNC_PRE(erf, std::erf(x.get_value()), 
         two_over_sqrt_pi * std::exp(-t_sq), 
         static constexpr double two_over_sqrt_pi =
                 1.1283791670955126;

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
 
-CXX_STD = CXX20
+CXX_STD = CXX17
 
 PKG_CPPFLAGS=-I../inst/include

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 
-CXX_STD = CXX20
+CXX_STD = CXX17
 
 PKG_CPPFLAGS=-I../inst/include


### PR DESCRIPTION
The issue was that the compiler wanted my macro `FORWARD_UNARY_FUNC` to have at least one argument in the variadic argument list. But sometimes I used it with no variadic arguments. I separated the two use cases and now have 2 macros. `FORWARD_UNARY_FUNC_PRE` is only used in the case when there's at least one variadic argument and `FORWARD_UNARY_FUNC` for no variadic arguments. Quick and dirty lol.